### PR TITLE
Fix dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     packages=setuptools.find_packages(where="."),
     install_requires=[
         'opencv-python',
-        'lzf',
+        'python-lzf',
     ],
     python_requires=">=3.6",
 )


### PR DESCRIPTION
The dependency of pypcd should be python-lzf (https://github.com/teepark/python-lzf) instead of lzf (https://github.com/lordmauve/lzf).