### PR TITLE
fix: add another version of time conversion

### DIFF
--- a/record_msg/builder.py
+++ b/record_msg/builder.py
@@ -25,7 +25,7 @@ from modules.common_msgs.sensor_msgs import sensor_image_pb2, pointcloud_pb2, im
 from modules.common_msgs.localization_msgs import localization_pb2
 from modules.common_msgs.transform_msgs import transform_pb2
 
-from record_msg.time_conversion import unix2gps
+from record_msg.time_conversion import Unix2Gps
 
 class Builder(object):
   def __init__(self) -> None:
@@ -115,7 +115,7 @@ class IMUBuilder(Builder):
     if measurement_time is not None:
       pb_imu.measurement_time = measurement_time
     else:
-      pb_imu.measurement_time = unix2gps(t)
+      pb_imu.measurement_time = Unix2Gps(t)
 
     if measurement_span is not None:
       pb_imu.measurement_span = measurement_span

--- a/record_msg/time_conversion.py
+++ b/record_msg/time_conversion.py
@@ -112,3 +112,22 @@ def gps2unix(gps_seconds):
     if result >= seconds:
       return result
   return 0
+
+# There are two versions of time conversion in Apollo's source code
+# https://github.com/ApolloAuto/apollo/issues/15499
+# There is still no conclusion on which one is correct.
+# This version is correct for MSF Localization.
+UNIX_GPS_DIFF = 315964782
+LEAP_SECOND_TIMESTAMP = 1483228799
+
+def Unix2Gps(unix_time):
+    gps_time = unix_time - UNIX_GPS_DIFF
+    if (unix_time < LEAP_SECOND_TIMESTAMP):
+        gps_time -= 1.0
+    return gps_time
+
+def Gps2Unix(gps_time):
+    unix_time = gps_time + UNIX_GPS_DIFF
+    if (unix_time + 1 < LEAP_SECOND_TIMESTAMP):
+        unix_time += 1.0
+    return unix_time


### PR DESCRIPTION
This version works correctly for GPS and IMU time in MSF localization ApolloAuto/apollo#15499
This implementation is adapted from https://github.com/ApolloAuto/apollo/blob/v9.0.0/modules/common/util/time_util.h